### PR TITLE
Provided optimized is_X_ip subs when inet_pton is available

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,11 @@
 {{$NEXT}}
 
+- If your version of Socket.pm provides a sane inet_pton, most of the
+  is_*_ip subroutines will use a much faster implementation. is_private_ipv4
+  and is_private_ipv4 are approximately 16x faster. is_private_ipv6 and
+  is_public_ipv6 are about 3-4x faster.
+
+
 0.26  2016-05-31
 
 - Fixed issue where invalid IPv6 strings such as ::0000000 would be marked as
@@ -24,6 +30,7 @@
 - A string with a null byte (\0) would be considered valid if the internal
   implementation used inet_pton() to validate IP addresses. Fixed by Greg
   Oschwald. GitHub PR #4.
+
 
 0.23     2014-03-09
 
@@ -199,4 +206,3 @@
 0.01     2005-03-03
 
 - Original version; created by h2xs 1.23 with options -AXn Data::Validate::IP
-

--- a/bench/is-private-public
+++ b/bench/is-private-public
@@ -1,0 +1,47 @@
+use strict;
+use warnings;
+
+use Benchmark qw( timethese );
+
+use Data::Validate::IP;
+
+my @bad = ('a' .. 'z', undef, 0);
+
+my @ipv4 = @bad;
+for (1 .. 500) {
+    push @ipv4, _random_ipv4();
+}
+
+my @ipv6 = @bad;
+push @ipv6, '::', '::0';
+for (1 .. 500) {
+    push @ipv6, _random_ipv6();
+}
+
+timethese(
+    2000,
+    {
+        'is_public_ipv4' =>
+            sub { Data::Validate::IP::is_public_ipv4($_) for @ipv4 },
+        'is_private_ipv4' =>
+            sub { Data::Validate::IP::is_private_ipv4($_) for @ipv4 },
+    }
+);
+
+timethese(
+    2000,
+    {
+        'is_public_ipv6' =>
+            sub { Data::Validate::IP::is_public_ipv6($_) for @ipv6 },
+        'is_private_ipv6' =>
+            sub { Data::Validate::IP::is_private_ipv6($_) for @ipv6 },
+    }
+);
+
+sub _random_ipv4 {
+    return join '.', map { int(rand(256)) } 1 .. 4;
+}
+
+sub _random_ipv6 {
+    return join '::', map { sprintf('%4x', int(rand(2**16))) } 1 .. 8;
+}


### PR DESCRIPTION
Benchmark when `inet_pton` is available:

```
$ perl  -Ilib bench/test 
Benchmark: timing 2000 iterations of is_private_ipv4, is_public_ipv4...
is_private_ipv4:  1 wallclock secs ( 0.70 usr +  0.00 sys =  0.70 CPU) @ 2857.14/s (n=2000)
is_public_ipv4:  2 wallclock secs ( 1.55 usr +  0.00 sys =  1.55 CPU) @ 1290.32/s (n=2000)
Benchmark: timing 2000 iterations of is_private_ipv6, is_public_ipv6...
is_private_ipv6:  0 wallclock secs ( 0.54 usr +  0.00 sys =  0.54 CPU) @ 3703.70/s (n=2000)
is_public_ipv6:  1 wallclock secs ( 0.54 usr +  0.00 sys =  0.54 CPU) @ 3703.70/s (n=2000)
```

Benchmark using old code without it:

```
$ DVI_NO_SOCKET=1 perl -Ilib bench/test 
Benchmark: timing 2000 iterations of is_private_ipv4, is_public_ipv4...
is_private_ipv4: 13 wallclock secs (13.16 usr +  0.43 sys = 13.59 CPU) @ 147.17/s (n=2000)
is_public_ipv4: 26 wallclock secs (24.94 usr +  0.44 sys = 25.38 CPU) @ 78.80/s (n=2000)
Benchmark: timing 2000 iterations of is_private_ipv6, is_public_ipv6...
is_private_ipv6:  1 wallclock secs ( 1.60 usr +  0.00 sys =  1.60 CPU) @ 1250.00/s (n=2000)
is_public_ipv6:  2 wallclock secs ( 1.62 usr +  0.00 sys =  1.62 CPU) @ 1234.57/s (n=2000)
```